### PR TITLE
bump dependency versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,12 @@ jobs:
           name: Build library for native target
           command: cargo build --locked
       - run:
+          name: Build library for Wasm target (default features)
+          command: cargo build --target wasm32-unknown-unknown --locked
+      - run:
+          name: Build library for Wasm target (all features)
+          command: cargo build --target wasm32-unknown-unknown --locked --all-features
+      - run:
           name: Run unit tests
           command: cargo test --locked
       - save_cache:
@@ -77,12 +83,6 @@ jobs:
       - run:
           name: Build library for native target
           command: cargo build -Zminimal-versions --all-features
-      - run:
-          name: Build library for Wasm target (default features)
-          command: cargo build --target wasm32-unknown-unknown --locked
-      - run:
-          name: Build library for Wasm target (all features)
-          command: cargo build --target wasm32-unknown-unknown --locked --all-features
       - run:
           name: Run unit tests
           command: cargo test --workspace -Zminimal-versions --all-features

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,9 @@ jobs:
           name: Version information
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - run:
+          name: Add wasm32 target
+          command: rustup target add wasm32-unknown-unknown && rustup target list --installed
+      - run:
           name: Generate a lockfile
           command: cargo update
       - restore_cache:
@@ -74,6 +77,12 @@ jobs:
       - run:
           name: Build library for native target
           command: cargo build -Zminimal-versions --all-features
+      - run:
+          name: Build library for Wasm target (default features)
+          command: cargo build --target wasm32-unknown-unknown --locked
+      - run:
+          name: Build library for Wasm target (all features)
+          command: cargo build --target wasm32-unknown-unknown --locked --all-features
       - run:
           name: Run unit tests
           command: cargo test --workspace -Zminimal-versions --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,7 +209,6 @@ dependencies = [
 name = "cw-utils"
 version = "1.0.0"
 dependencies = [
- "anyhow",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus 1.0.1",
@@ -218,7 +217,6 @@ dependencies = [
  "schemars",
  "semver",
  "serde",
- "serde_json",
  "thiserror",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,6 +209,7 @@ dependencies = [
 name = "cw-utils"
 version = "1.0.0"
 dependencies = [
+ "anyhow",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus 1.0.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,9 +70,9 @@ checksum = "722e23542a15cea1f65d4a1419c4cfd7a26706c70871a13a04238ca3f40f1661"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "1.1.5"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28376836c7677e1ea6d6656a754582e88b91e544ce22fae42956d5fe5549a958"
+checksum = "227315dc11f0bb22a273d0c43d3ba8ef52041c42cf959f09045388a89c57e661"
 dependencies = [
  "digest 0.10.5",
  "ed25519-zebra",
@@ -83,18 +83,18 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.1.5"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eb69f4f7a8a4bce68c8fbd3646238fede1e77056e4ea31c5b6bfc37b709eec3"
+checksum = "6fca30d51f7e5fbfa6440d8b10d7df0231bdf77e97fd3fe5d0cb79cc4822e50c"
 dependencies = [
  "syn",
 ]
 
 [[package]]
 name = "cosmwasm-schema"
-version = "1.1.5"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a227cfeb9a7152b26a354b1c990e930e962f75fd68f57ab5ae2ef888c8524292"
+checksum = "04135971e2c3b867eb793ca4e832543c077dbf72edaef7672699190f8fcdb619"
 dependencies = [
  "cosmwasm-schema-derive",
  "schemars",
@@ -105,9 +105,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema-derive"
-version = "1.1.5"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3626cb42eef870de67f791e873711255325224d86f281bf628c42abd295f3a14"
+checksum = "a06c8f516a13ae481016aa35f0b5c4652459e8aee65b15b6fb51547a07cea5a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -116,9 +116,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.1.5"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46bf9157d060abbc55152aeadcace799d03dc630575daa66604079a1206cb060"
+checksum = "b13d5a84d15cf7be17dc249a21588cdb0f7ef308907c50ce2723316a7d79c3dc"
 dependencies = [
  "base64",
  "cosmwasm-crypto",
@@ -195,15 +195,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "cw-storage-plus"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053a5083c258acd68386734f428a5a171b29f7d733151ae83090c6fcc9417ffa"
+dependencies = [
+ "cosmwasm-std",
+ "schemars",
+ "serde",
+]
+
+[[package]]
 name = "cw-utils"
 version = "1.0.0"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus",
+ "cw-storage-plus 1.0.1",
  "cw2",
- "k256",
  "prost",
  "schemars",
  "semver",
@@ -214,13 +224,13 @@ dependencies = [
 
 [[package]]
 name = "cw2"
-version = "0.16.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91398113b806f4d2a8d5f8d05684704a20ffd5968bf87e3473e1973710b884ad"
+checksum = "03bdf3747540b47bc1bdaf50ba3aa5e4276ab0c2ce73e8b367ebe260cc37ff9c"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus",
+ "cw-storage-plus 0.16.0",
  "schemars",
  "serde",
 ]
@@ -459,9 +469,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.9.0"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
+checksum = "c0b18e655c21ff5ac2084a5ad0611e827b3f92badf79f4910b5a5c58f4d87ff0"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -469,9 +479,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.9.0"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
+checksum = "164ae68b6587001ca506d3bf7f1000bfa248d0e1217b618108fba4ec1d0cc306"
 dependencies = [
  "anyhow",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,5 @@ thiserror = "1.0.13"
 
 [dev-dependencies]
 cw-storage-plus = "1.0.1"
-prost = "0.11"
+prost = "0.11.0"
+anyhow = "1.0.65" # Not used directly but prost-derive does not set a sufficiently high anyhow version

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,23 +11,19 @@ homepage = "https://cosmwasm.com"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cosmwasm-schema = "1.0.0"
-cosmwasm-std = "1.0.0"
-cw2 = "0.16"
+cosmwasm-schema = "1.1.9"
+cosmwasm-std = "1.1.9"
+cw2 = "1.0.0"
 schemars = "0.8.1"
 semver = "1"
 serde = { version = "1.0.0", default-features = false, features = ["derive"] }
 thiserror = "1.0.13"
 
-# We don't use the following dependencies directly. They're dependencies of our dependencies.
-# We specify them to tighten their version requirements so that builds with `-Zminimal-versions` work.
-# Once we bump `cosmwasm-*` deps to a version after `1.1.5`, we can remove these.
-k256 = { version = "0.11.1", features = ["ecdsa"] }
 anyhow = "1.0.41"
 
 [dev-dependencies]
-cw-storage-plus = "0.16"
-prost = "0.9"
+cw-storage-plus = "1.0.1"
+prost = "0.11"
 
 # We don't use the following dependencies directly. They're dependencies of our dependencies.
 # We specify them to tighten their version requirements so that builds with `-Zminimal-versions` work.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,13 +19,6 @@ semver = "1"
 serde = { version = "1.0.0", default-features = false, features = ["derive"] }
 thiserror = "1.0.13"
 
-anyhow = "1.0.41"
-
 [dev-dependencies]
 cw-storage-plus = "1.0.1"
 prost = "0.11"
-
-# We don't use the following dependencies directly. They're dependencies of our dependencies.
-# We specify them to tighten their version requirements so that builds with `-Zminimal-versions` work.
-# Once we bump `cosmwasm-*` deps to a version after `1.1.5`, we can remove these.
-serde_json = "1.0.40"


### PR DESCRIPTION
Closes: https://github.com/CosmWasm/cw-utils/issues/3

Including `k256` as a dependency leads to a compilation error:

```plain
$ cargo build --target wasm32-unknown-unknown
```

```plain
Compiling subtle v2.4.1
   Compiling cfg-if v1.0.0
   Compiling zeroize v1.5.7
   Compiling const-oid v0.9.0
   Compiling itoa v1.0.4
   Compiling base64ct v1.5.3
   Compiling typenum v1.15.0
   Compiling serde v1.0.145
   Compiling serde_json v1.0.86
   Compiling ryu v1.0.11
   Compiling generic-array v0.14.6
   Compiling schemars v0.8.11
   Compiling crunchy v0.2.2
   Compiling dyn-clone v1.0.9
   Compiling thiserror v1.0.37
   Compiling hex v0.4.3
   Compiling getrandom v0.2.7
error: the wasm32-unknown-unknown target is not supported by default, you may need to enable the "js" feature. For more information see: https://docs.rs/getrandom/#webassembly-support
   --> /Users/larry/.cargo/registry/src/github.com-1ecc6299db9ec823/getrandom-0.2.7/src/lib.rs:235:9
    |
235 | /         compile_error!("the wasm32-unknown-unknown target is not supported by \
236 | |                         default, you may need to enable the \"js\" feature. \
237 | |                         For more information see: \
238 | |                         https://docs.rs/getrandom/#webassembly-support");
    | |________________________________________________________________________^

   Compiling base16ct v0.1.1
error[E0433]: failed to resolve: use of undeclared crate or module `imp`
   --> /Users/larry/.cargo/registry/src/github.com-1ecc6299db9ec823/getrandom-0.2.7/src/lib.rs:262:5
    |
262 |     imp::getrandom_inner(dest)
    |     ^^^ use of undeclared crate or module `imp`

For more information about this error, try `rustc --explain E0433`.
error: could not compile `getrandom` due to 2 previous errors
warning: build failed, waiting for other jobs to finish...
```

This PR removes `k256` and bump all dependencies to latest.