### PR TITLE
Add exact funds sent assertion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- `exact_funds_sent()` helper to assert the exact funds in `MessageInfo`.
+
 ## [v1.0.0](https://github.com/CosmWasm/cw-utils/tree/v1.0.0) (2022-11-23)
 
 [Full Changelog](https://github.com/CosmWasm/cw-utils/compare/v0.16.0...v1.0.0)


### PR DESCRIPTION
It's a common need to assert the exact amount of coins have been sent in `MessageInfo`. This PR adds a helper to cw-utils so it's accessible to all.

Note:
- If the `Coin` struct implemented the `Hash` trait, there wouldn't be a need to do it here. If interested, I can create a PR there instead.
- Same thing with Stringifying a `Vec<Coin>` or `&[Coin]`. Those also would be nice to have in the standard lib.
- At the moment, this function "respects" if you send duplicates in given the length check. Perhaps this is not necessary.