### PR TITLE
Deprecate `ensure_from_older_version`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ mod payment;
 mod scheduled;
 mod threshold;
 
+#[allow(deprecated)]
 pub use migrate::ensure_from_older_version;
 pub use pagination::{
     calc_range_end, calc_range_start, calc_range_start_string, maybe_addr, maybe_canonical,

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -5,6 +5,7 @@ use semver::Version;
 /// This function not only validates that the right contract and version can be migrated, but also
 /// updates the contract version from the original (stored) version to the new version.
 /// It returns the original version for the convenience of doing external checks.
+#[deprecated(note = "Use cw2::ensure_from_older_version, which is an equivalent of this function.")]
 pub fn ensure_from_older_version(
     storage: &mut dyn Storage,
     name: &str,
@@ -39,6 +40,7 @@ fn from_semver(err: semver::Error) -> StdError {
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     use super::*;
     use cosmwasm_std::testing::MockStorage;


### PR DESCRIPTION
This is in cw2 from the next release onwards.

Part of #12